### PR TITLE
Add compress option to gzip Gelf message sent

### DIFF
--- a/lib/Log/Dispatch/Gelf.pm
+++ b/lib/Log/Dispatch/Gelf.pm
@@ -185,6 +185,10 @@ parameters documented in L<Log::Dispatch::Output>:
 optional hashref of additional fields of the gelf message (no need to prefix
 them with _, the prefixing is done automatically).
 
+=item compress
+
+optional scalar. If a true value the message will be gzipped with
+IO::Compress::Gzip.
 
 =item send_sub
 

--- a/lib/Log/Dispatch/Gelf.pm
+++ b/lib/Log/Dispatch/Gelf.pm
@@ -89,11 +89,13 @@ sub _create_socket {
     my ($self, $socket_opts) = @_;
 
     require IO::Socket::INET;
-    return IO::Socket::INET->new(
+    my $socket = IO::Socket::INET->new(
         PeerAddr => $socket_opts->{host},
         PeerPort => $socket_opts->{port},
         Proto    => $socket_opts->{protocol},
     ) or die "Cannot create socket: $!";
+
+    return $socket;
 }
 
 sub log_message {


### PR DESCRIPTION
I needed to add this in order to log via Logstash as its Gelf input does not support raw messages.

I also shushed a warning on Perl v20 and above in the `_create_socket` method.