### PR TITLE
Add GELF UDP chunking

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires 'perl', '5.010';
 requires 'Log::Dispatch';
 requires 'Time::HiRes';
 requires 'JSON';
+requires 'Math::Random::MT';
 
 recommends 'JSON::XS', '2.0';
 

--- a/lib/Log/Dispatch/Gelf.pm
+++ b/lib/Log/Dispatch/Gelf.pm
@@ -105,7 +105,6 @@ sub _init {
     $self->{host}              = $p{host}              // hostname();
     $self->{additional_fields} = $p{additional_fields} // {};
     $self->{send_sub}          = $p{send_sub};
-    $self->{chunked}           = $p{chunked};
     $self->{gelf_version}      = '1.1';
 
     if ($p{socket}) {

--- a/lib/Log/Dispatch/Gelf.pm
+++ b/lib/Log/Dispatch/Gelf.pm
@@ -55,7 +55,7 @@ sub _init {
                         # WAN: 1500 - 8 b (UDP header) - 60 b (max IP header) - 12 b (chunking header) = 1420 b
                         # LAN: 8192 - 8 b (UDP header) - 20 b (min IP header) - 12 b (chunking header) = 8152 b
                         # Note that based on my calculation the Graylog LAN
-                        #  default may be 2 bytes too big (8194)
+                        #  default may be 2 bytes too big (8154)
                         # See http://stackoverflow.com/questions/14993000/the-most-reliable-and-efficient-udp-packet-size
                         # For some discussion. I don't think this is an exact science!
                         if ( lc($1) eq 'wan' ) {

--- a/lib/Log/Dispatch/Gelf.pm
+++ b/lib/Log/Dispatch/Gelf.pm
@@ -80,12 +80,6 @@ sub _init {
                         $socket->{port} //= 12201;
                         die 'socket port must be integer' unless $socket->{port} =~ /^\d+$/;
                     },
-                    protocol_udp_if_chunked => sub {
-                        my ($socket) = @_;
-
-                        die 'socket chunked only applicable to udp'
-                            unless ! exists $socket->{chunked} || $socket->{protocol} eq 'udp';
-                    },
                 }
             }
         }

--- a/lib/Log/Dispatch/Gelf.pm
+++ b/lib/Log/Dispatch/Gelf.pm
@@ -67,7 +67,7 @@ sub _init {
                         my ($socket) = @_;
 
                         $socket->{protocol} //= 'udp';
-                        die 'socket protocol must be tcp or udp' unless $socket->{protocol} =~ /^(tcp|udp)$/;
+                        die 'socket protocol must be tcp or udp' unless $socket->{protocol} =~ /^(?:tcp|udp)$/;
                     },
                     host_must_be_set => sub {
                         my ($socket) = @_;

--- a/lib/Log/Dispatch/Gelf.pm
+++ b/lib/Log/Dispatch/Gelf.pm
@@ -47,11 +47,22 @@ sub _init {
                         die 'chunked must be "wan", "lan", or a positive integer'
                             unless $chunked =~ /^(wan|lan|\d+)$/i;
 
+                        # These default values below were determined by
+                        # examining the code for Graylog's implementation. See
+                        #  https://github.com/Graylog2/gelf-rb/blob/master/lib/gelf/notifier.rb#L62
+                        # I believe these ae determined by likely MTU defaults
+                        #  and possible heasers like so...
+                        # WAN: 1500 - 8 b (UDP header) - 60 b (max IP header) - 12 b (chunking header) = 1420 b
+                        # LAN: 8192 - 8 b (UDP header) - 20 b (min IP header) - 12 b (chunking header) = 8152 b
+                        # Note that based on my calculation the Graylog LAN
+                        #  default may be 2 bytes too big (8194)
+                        # See http://stackoverflow.com/questions/14993000/the-most-reliable-and-efficient-udp-packet-size
+                        # For some discussion. I don't think this is an exact science!
                         if ( lc($1) eq 'wan' ) {
                             $self->{chunked} = 1420;
                         }
                         elsif ( lc($1) eq 'lan' ) {
-                            $self->{chunked} = 8154;
+                            $self->{chunked} = 8152;
                         }
                         else {
                             $self->{chunked} = $1;

--- a/lib/Log/Dispatch/Gelf.pm
+++ b/lib/Log/Dispatch/Gelf.pm
@@ -44,7 +44,7 @@ sub _init {
                         my ($socket) = @_;
 
                         $socket->{protocol} //= 'udp';
-                        die 'socket protocol must be tcp or udp' unless $socket->{protocol} =~ /^tcp|udp$/;
+                        die 'socket protocol must be tcp or udp' unless $socket->{protocol} =~ /^(tcp|udp)$/;
                     },
                     host_must_be_set => sub {
                         my ($socket) = @_;

--- a/t/02_socket.t
+++ b/t/02_socket.t
@@ -81,6 +81,23 @@ throws_ok {
 }
 qr/socket protocol must be tcp or udp/, 'invalid protocol';
 
+throws_ok {
+    Log::Dispatch->new(
+        outputs => [
+            [
+                'Gelf',
+                min_level => 'debug',
+                'socket'  => {
+                    host     => 'test',
+                    port     => '111111',
+                    protocol => 'xxx-udp',
+                }
+            ]
+        ],
+    );
+}
+qr/socket protocol must be tcp or udp/, 'invalid protocol 2';
+
 my $LAST_LOG_MSG;
 my $class_inet = qclass(
     -implement => 'IO::Socket::INET',
@@ -145,4 +162,4 @@ is($msg->{level},         6,                           'correct level info');
 is($msg->{short_message}, 'Compressed',                'short_message correct');
 is($msg->{full_message},  "Compressed\nMore details.", 'full_message correct');
 
-done_testing(13);
+done_testing(14);

--- a/t/03_chunked.t
+++ b/t/03_chunked.t
@@ -98,6 +98,34 @@ throws_ok {
 }
 qr/chunked must be "wan", "lan", or a positive integer/, 'invalid integer';
 
+new_ok ( 'Log::Dispatch', [
+        outputs => [
+            [
+                'Gelf',
+                min_level => 'debug',
+                chunked  => 'WAN',
+                socket    => {
+                    host => 'test',
+                }
+            ]
+        ]
+    ]
+);
+
+new_ok ( 'Log::Dispatch', [
+        outputs => [
+            [
+                'Gelf',
+                min_level => 'debug',
+                chunked  => 'lan',
+                socket    => {
+                    host => 'test',
+                }
+            ]
+        ]
+    ]
+);
+
 my $log = Log::Dispatch->new(
     outputs => [
         [
@@ -148,4 +176,4 @@ is($msg->{level},         6,                                     'correct level 
 is($msg->{short_message}, 'Compressed - chunked',                'short_message correct');
 is($msg->{full_message},  "Compressed - chunked\nMore details.", 'full_message correct');
 
-done_testing(9);
+done_testing(11);

--- a/t/03_chunked.t
+++ b/t/03_chunked.t
@@ -1,0 +1,151 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Log::Dispatch;
+use JSON;
+use Test::Exception;
+use Mock::Quick;
+use IO::Uncompress::Gunzip qw(gunzip $GunzipError);
+
+my $CHUNKED_MESSAGE;
+my $class_inet = qclass(
+    -implement => 'IO::Socket::INET',
+    new        => sub {
+        my ($obj, %options) = @_;
+        $CHUNKED_MESSAGE = undef;
+        return bless {}, $obj;
+    },
+    send => sub {
+        my ($self, $msg) = @_;
+        
+        my $magic = pack('C*', 0x1e, 0x0f);
+        
+        my @msg = split //, $msg;
+        
+        my $msg_magic   = join '', splice @msg, 0, 2;
+        my $msg_id      = unpack('LL', join '', splice @msg, 0, 8);
+        my $msg_seq_no  = unpack('C', shift @msg);
+        my $msg_seq_cnt = unpack('C', shift @msg);
+
+        $self->{last_msg_id} = $msg_id;
+
+        if ( $msg_magic eq $magic ) {
+            die "sequence_number > sequence count - should not happen"
+              if $msg_seq_no > $msg_seq_cnt;
+
+            die "message_id <> last message_id - should not happen"
+              if defined $self->{last_msg_id} && $self->{last_msg_id} ne $msg_id;
+
+            $CHUNKED_MESSAGE .= join '', @msg;
+            
+        }
+        else {
+            die "message not chunked";
+        }
+    }
+);
+
+throws_ok {
+    Log::Dispatch->new(
+        outputs => [
+            [
+                'Gelf',
+                min_level => 'debug',
+                chunked  => 'WAN',
+                'socket'  => {
+                    host     => 'test',
+                    protocol => 'tcp',
+                }
+            ]
+        ],
+    );
+}
+qr/chunked only applicable to udp/, 'invalid protocol for chunking';
+
+throws_ok {
+    Log::Dispatch->new(
+        outputs => [
+            [
+                'Gelf',
+                min_level => 'debug',
+                chunked   => 'xxx',
+                'socket'  => {
+                    host     => 'test',
+                    protocol => 'udp',
+                }
+            ]
+        ],
+    );
+}
+qr/chunked must be "wan", "lan", or a positive integer/, 'invalid chunked value';
+
+throws_ok {
+    Log::Dispatch->new(
+        outputs => [
+            [
+                'Gelf',
+                min_level => 'debug',
+                chunked   => '-1',
+                'socket'  => {
+                    host     => 'test',
+                    protocol => 'udp',
+                }
+            ]
+        ],
+    );
+}
+qr/chunked must be "wan", "lan", or a positive integer/, 'invalid integer';
+
+my $log = Log::Dispatch->new(
+    outputs => [
+        [
+            'Gelf',
+            min_level => 'debug',
+            chunked  => 4,
+            socket    => {
+                host => 'test',
+            }
+        ]
+    ],
+);
+
+$log->info("Uncompressed - chunked\nMore details.");
+
+note("formatted message: $CHUNKED_MESSAGE");
+
+my $msg = decode_json($CHUNKED_MESSAGE);
+
+is($msg->{level},         6,                                       'correct level info');
+is($msg->{short_message}, 'Uncompressed - chunked',                'short_message correct');
+is($msg->{full_message},  "Uncompressed - chunked\nMore details.", 'full_message correct');
+
+$log = Log::Dispatch->new(
+    outputs => [
+        [
+            'Gelf',
+            min_level  => 'debug',
+            compress => 1,
+            chunked  => 4,
+            socket    => {
+                host => 'test',
+            }
+        ]
+    ],
+);
+
+$log->info("Compressed - chunked\nMore details.");
+
+my $output;
+gunzip \$CHUNKED_MESSAGE => \$output
+    or die "gunzip failed: $GunzipError\n";
+note("formatted message: $output");
+
+$msg = decode_json($output);
+
+is($msg->{level},         6,                                     'correct level info');
+is($msg->{short_message}, 'Compressed - chunked',                'short_message correct');
+is($msg->{full_message},  "Compressed - chunked\nMore details.", 'full_message correct');
+
+done_testing(9);

--- a/t/03_chunked.t
+++ b/t/03_chunked.t
@@ -29,8 +29,6 @@ my $class_inet = qclass(
         my $msg_seq_no  = unpack('C', shift @msg);
         my $msg_seq_cnt = unpack('C', shift @msg);
 
-        $self->{last_msg_id} = $msg_id;
-
         if ( $msg_magic eq $magic ) {
             die "sequence_number > sequence count - should not happen"
               if $msg_seq_no > $msg_seq_cnt;
@@ -38,8 +36,10 @@ my $class_inet = qclass(
             die "message_id <> last message_id - should not happen"
               if defined $self->{last_msg_id} && $self->{last_msg_id} ne $msg_id;
 
+            $self->{last_msg_id} = $msg_id;
+
             $CHUNKED_MESSAGE .= join '', @msg;
-            
+
         }
         else {
             die "message not chunked";


### PR DESCRIPTION
Thanks for accepting my previous PR! This one adds GELF chunking for UDP sockets and associated tests. I have tested this against the GELF input of Logstash (latest stable and 1.5) and it works there perfectly.

It also contains a fix and test for a minor bug where a socket protocol of `xxx-udp` (for example) would pass the class initialisation argument checks.