### PR TITLE
Subclass log method to allow per log additional fields

### DIFF
--- a/t/01_log_format.t
+++ b/t/01_log_format.t
@@ -1,5 +1,6 @@
 use strict;
 use Test::More;
+use Test::Exception;
 
 use Log::Dispatch;
 use JSON;
@@ -28,4 +29,52 @@ ok($msg->{host}, 'host is there');
 ok($msg->{timestamp}, 'timestamp is there');
 ok($msg->{version}, 'version is there');
 
-done_testing();
+dies_ok {
+    $log->log(
+        level             => 'info',
+        message           => "It works\nMore details.",
+        additional_fields => 'not a hashref'
+    );
+}
+'additional_fields wrong type';
+
+$log->log(
+    level             => 'info',
+    message           => "It works\nMore details.",
+    additional_fields => { additional => 1 }
+);
+
+note "formatted message: $LAST_LOG_MSG";
+
+$msg = decode_json($LAST_LOG_MSG);
+is($msg->{level}, 6, 'correct level info');
+is($msg->{short_message}, 'It works', 'short_message correct');
+is($msg->{full_message}, "It works\nMore details.", 'full_message correct');
+is($msg->{_facility}, __FILE__, 'facility correct');
+is($msg->{_additional}, 1, 'additional log field correct');
+ok($msg->{host}, 'host is there');
+ok($msg->{timestamp}, 'timestamp is there');
+ok($msg->{version}, 'version is there');
+
+$log->log(
+    level            => 'info',
+    message           => "It works\nMore details.",
+    additional_fields => { facility => 'override' }
+);
+
+note "formatted message: $LAST_LOG_MSG";
+
+$msg = decode_json($LAST_LOG_MSG);
+is($msg->{_facility}, 'override', 'facility overridden correctly');
+
+$log->log(
+    level            => 'info',
+    message           => "It works\nMore details.",
+);
+
+note "formatted message: $LAST_LOG_MSG";
+
+$msg = decode_json($LAST_LOG_MSG);
+is($msg->{_facility}, __FILE__, 'override is temporary');
+
+done_testing(18);

--- a/t/01_log_format.t
+++ b/t/01_log_format.t
@@ -57,7 +57,7 @@ ok($msg->{timestamp}, 'timestamp is there');
 ok($msg->{version}, 'version is there');
 
 $log->log(
-    level            => 'info',
+    level             => 'info',
     message           => "It works\nMore details.",
     additional_fields => { facility => 'override' }
 );
@@ -68,8 +68,8 @@ $msg = decode_json($LAST_LOG_MSG);
 is($msg->{_facility}, 'override', 'facility overridden correctly');
 
 $log->log(
-    level            => 'info',
-    message           => "It works\nMore details.",
+    level   => 'info',
+    message => "It works\nMore details.",
 );
 
 note "formatted message: $LAST_LOG_MSG";


### PR DESCRIPTION
Let me know what you think about this addition. We need to pass different `additional_fields` through per log message. Currently I am passing in a hashref to the constructor and keeping the reference to it around, clearing and setting it again per call to log(). That's a bit nasty and this PR would allow us to do it more clearly and cleanly. Thanks!