### PR TITLE
Log gelf util

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'perl', '5.010';
 requires 'Log::Dispatch';
-requires 'Log::GELF::Util', '0.90';
+requires 'Log::GELF::Util', '>= 0.90';
 
 recommends 'JSON::XS', '2.0';
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'perl', '5.010';
 requires 'Log::Dispatch';
+requires 'Log::GELF::Util', '0.90';
 requires 'Time::HiRes';
 requires 'JSON';
 requires 'Math::Random::MT';

--- a/cpanfile
+++ b/cpanfile
@@ -1,9 +1,6 @@
 requires 'perl', '5.010';
 requires 'Log::Dispatch';
 requires 'Log::GELF::Util', '0.90';
-requires 'Time::HiRes';
-requires 'JSON';
-requires 'Math::Random::MT';
 
 recommends 'JSON::XS', '2.0';
 
@@ -11,5 +8,6 @@ on 'test' => sub {
     requires 'Test::More', '0.98';
     requires 'Mock::Quick', '1.107';
     requires 'Test::Exception', '0.31';
+    requires 'JSON';
 };
 

--- a/lib/Log/Dispatch/Gelf.pm
+++ b/lib/Log/Dispatch/Gelf.pm
@@ -219,7 +219,7 @@ them with _, the prefixing is done automatically).
 =item chunked
 
 optional scalar. An integer specifying the chunk size or the special
-string values 'lan' or 'wan' corresponging to 8154 or 1420 respectively.
+string values 'lan' or 'wan' corresponding to 8154 or 1420 respectively.
 A zero chunk size means no chunking will be applied.
 
 Chunking is only applicable to UDP connections.

--- a/t/03_chunked.t
+++ b/t/03_chunked.t
@@ -17,7 +17,7 @@ my $class_inet = qclass(
     new        => sub {
         my ($obj, %options) = @_;
         @ACCUMULATOR = undef;
-        $MESSAGE                     = undef;
+        $MESSAGE     = undef;
         return bless {}, $obj;
     },
     send => sub {

--- a/t/03_chunked.t
+++ b/t/03_chunked.t
@@ -64,40 +64,6 @@ throws_ok {
 }
 qr/chunked only applicable to udp/, 'invalid protocol for chunking';
 
-throws_ok {
-    Log::Dispatch->new(
-        outputs => [
-            [
-                'Gelf',
-                min_level => 'debug',
-                chunked   => 'xxx',
-                'socket'  => {
-                    host     => 'test',
-                    protocol => 'udp',
-                }
-            ]
-        ],
-    );
-}
-qr/chunked must be "wan", "lan", or a positive integer/, 'invalid chunked value';
-
-throws_ok {
-    Log::Dispatch->new(
-        outputs => [
-            [
-                'Gelf',
-                min_level => 'debug',
-                chunked   => '-1',
-                'socket'  => {
-                    host     => 'test',
-                    protocol => 'udp',
-                }
-            ]
-        ],
-    );
-}
-qr/chunked must be "wan", "lan", or a positive integer/, 'invalid integer';
-
 new_ok ( 'Log::Dispatch', [
         outputs => [
             [
@@ -176,4 +142,4 @@ is($msg->{level},         6,                                     'correct level 
 is($msg->{short_message}, 'Compressed - chunked',                'short_message correct');
 is($msg->{full_message},  "Compressed - chunked\nMore details.", 'full_message correct');
 
-done_testing(11);
+done_testing(9);

--- a/t/03_chunked.t
+++ b/t/03_chunked.t
@@ -23,9 +23,9 @@ my $class_inet = qclass(
     send => sub {
         my ($self, $encoded_chunk) = @_;
         
-        $MESSAGE = Log::GELF::Util::dechunk(
+        $MESSAGE = dechunk(
             \@ACCUMULATOR,
-            Log::GELF::Util::decode_chunk($encoded_chunk)
+            decode_chunk($encoded_chunk)
         );
 
         $MESSAGE = uncompress($MESSAGE) if $MESSAGE;

--- a/t/03_chunked.t
+++ b/t/03_chunked.t
@@ -64,6 +64,40 @@ throws_ok {
 }
 qr/chunked only applicable to udp/, 'invalid protocol for chunking';
 
+throws_ok {
+    Log::Dispatch->new(
+        outputs => [
+            [
+                'Gelf',
+                min_level => 'debug',
+                chunked   => 'xxx',
+                'socket'  => {
+                    host     => 'test',
+                    protocol => 'udp',
+                }
+            ]
+        ],
+    );
+}
+qr/chunk size must be "lan", "wan", a positve integer, or 0 \(no chunking\)/, 'invalid chunked value';
+
+throws_ok {
+    Log::Dispatch->new(
+        outputs => [
+            [
+                'Gelf',
+                min_level => 'debug',
+                chunked   => '-1',
+                'socket'  => {
+                    host     => 'test',
+                    protocol => 'udp',
+                }
+            ]
+        ],
+    );
+}
+qr/chunk size must be "lan", "wan", a positve integer, or 0 \(no chunking\)/, 'invalid integer';
+
 new_ok ( 'Log::Dispatch', [
         outputs => [
             [
@@ -142,4 +176,4 @@ is($msg->{level},         6,                                     'correct level 
 is($msg->{short_message}, 'Compressed - chunked',                'short_message correct');
 is($msg->{full_message},  "Compressed - chunked\nMore details.", 'full_message correct');
 
-done_testing(9);
+done_testing(11);

--- a/t/03_chunked.t
+++ b/t/03_chunked.t
@@ -10,13 +10,13 @@ use Test::Exception;
 use Mock::Quick;
 use IO::Uncompress::Gunzip qw(gunzip $GunzipError);
 
-my @CHUNKED_MESSAGE_ACCUMULATOR;
+my @ACCUMULATOR;
 my $MESSAGE;
 my $class_inet = qclass(
     -implement => 'IO::Socket::INET',
     new        => sub {
         my ($obj, %options) = @_;
-        @CHUNKED_MESSAGE_ACCUMULATOR = undef;
+        @ACCUMULATOR = undef;
         $MESSAGE                     = undef;
         return bless {}, $obj;
     },
@@ -24,7 +24,7 @@ my $class_inet = qclass(
         my ($self, $encoded_chunk) = @_;
         
         $MESSAGE = Log::GELF::Util::dechunk(
-            \@CHUNKED_MESSAGE_ACCUMULATOR,
+            \@ACCUMULATOR,
             Log::GELF::Util::decode_chunk($encoded_chunk)
         );
 


### PR DESCRIPTION
I have released a [module](https://metacpan.org/pod/Log::GELF::Util) to CPAN which facilitates working with the GELF log format, it's based on the previous commits to your module but is more complete with regard to all of the GELF 1.1 specification. This PR delegates the majority of GELF related functions to that new module.

In addition to the tests for my new module and yours, I have tested my fork against Logstash's GELF input and it works as expected.

Let me know what you think. Note that I would be happy to grant you commit access to the new module and allow for co-maint of it on PAUSE if you would like.