### PR TITLE
FIx tests

### DIFF
--- a/META.json
+++ b/META.json
@@ -42,7 +42,7 @@
       },
       "runtime" : {
          "recommends" : {
-            "JSON::XS" : "2.0"
+            "Cpanel::JSON::XS" : "4"
          },
          "requires" : {
             "Log::Dispatch" : "0",
@@ -53,7 +53,7 @@
       },
       "test" : {
          "requires" : {
-            "JSON" : "0",
+            "JSON::MaybeXS" : "0",
             "Mock::Quick" : "1.107",
             "Test::Exception" : "0.31",
             "Test::More" : "0.98"

--- a/cpanfile
+++ b/cpanfile
@@ -3,12 +3,12 @@ requires 'Log::Dispatch';
 requires 'Log::GELF::Util', '>= 0.90';
 requires 'Params::Validate';
 
-recommends 'JSON::XS', '2.0';
+recommends 'Cpanel::JSON::XS', '4';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';
     requires 'Mock::Quick', '1.107';
     requires 'Test::Exception', '0.31';
-    requires 'JSON';
+    requires 'JSON::MaybeXS';
 };
 

--- a/t/01_log_format.t
+++ b/t/01_log_format.t
@@ -3,7 +3,7 @@ use Test::More;
 use Test::Exception;
 
 use Log::Dispatch;
-use JSON;
+use JSON::MaybeXS;
 
 my $LAST_LOG_MSG;
 

--- a/t/02_socket.t
+++ b/t/02_socket.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::More;
 
 use Log::Dispatch;
-use JSON;
+use JSON::MaybeXS;
 use Test::Exception;
 use Mock::Quick;
 use IO::Uncompress::Gunzip qw(gunzip $GunzipError);
@@ -185,6 +185,7 @@ $log->log(
 );
 ok(substr($LAST_LOG_MSG, -1) eq "\x00", 'TCP transport ends with a null byte');
 note("formatted message: $LAST_LOG_MSG");
+substr($LAST_LOG_MSG, -1) = '';
 $msg = decode_json($LAST_LOG_MSG);
 is($msg->{level},         6,                         'correct level info');
 is($msg->{short_message}, 'It works',                'short_message correct');

--- a/t/03_chunked.t
+++ b/t/03_chunked.t
@@ -5,7 +5,7 @@ use Test::More;
 
 use Log::Dispatch;
 use Log::GELF::Util qw(dechunk decode_chunk uncompress);
-use JSON;
+use JSON::MaybeXS;
 use Test::Exception;
 use Mock::Quick;
 use IO::Uncompress::Gunzip qw(gunzip $GunzipError);
@@ -22,7 +22,7 @@ my $class_inet = qclass(
     },
     send => sub {
         my ($self, $encoded_chunk) = @_;
-        
+
         $MESSAGE = dechunk(
             \@ACCUMULATOR,
             decode_chunk($encoded_chunk)


### PR DESCRIPTION
Hello!

I found out that tests for this module always fail with almost all JSON implementations in Perl except some versions of JSON::PP (or JSON::XS). Inside test file for sockets the encoded JSON string has a zero byte symbol at the end after TCP connection emulation. This is the reason why most JSON parsers fail to parse this string. They print the following error message:

`garbage after JSON object, at character offset 146 (before "\x{0}") at t/02_socket.t line 189.`

So i think that this symbol has to be removed before decoding.

Also I think that it would be better to use JSON::MaybeXS for testing and Cpanel::JSON::XS as recommended package because the last one is correct implementation of JSON (JSON::XS is incorrect) and the first one uses the last one inside as the primary package.